### PR TITLE
better timestamps on posts/comments, see examples in tests

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 	"time"
@@ -25,8 +26,24 @@ func (p *Post) CommentsCount() int {
 	return len(p.Comments)
 }
 
+func duration(d time.Duration) string {
+	if d.Hours() >= 24 {
+		// Days
+		return fmt.Sprintf("%dd", int(d.Hours()) / 24)
+	} else if d.Hours() >= 1 {
+		// Hours
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	} else if d.Minutes() >= 1 {
+		// Minutes
+		return fmt.Sprintf("%dm", int(d.Minutes()) % 60)
+	} else {
+		// Seconds
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+}
+
 func (p *Post) Ago() string {
-	return time.Since(p.CreatedAt).Truncate(time.Minute).String() + " ago"
+	return duration(time.Since(p.CreatedAt)) + " ago"
 }
 
 func (p *Post) Date() string {
@@ -49,7 +66,7 @@ type Comment struct {
 }
 
 func (c *Comment) Ago() string {
-	return time.Since(c.CreatedAt).Truncate(time.Minute).String() + " ago"
+	return duration(time.Since(c.CreatedAt)) + " ago"
 }
 
 func getEnv(k, def string) string {

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -1,0 +1,25 @@
+package db
+
+import (
+	"testing"
+	"time"
+)
+
+// Run some example durations and see how they look
+func TestDurationFormat(t *testing.T) {
+	compare(t, "730d", duration(2*365*24*time.Hour + 2*time.Minute))
+	compare(t, "14d", duration(14*24*time.Hour + 30*time.Minute))
+	compare(t, "2d", duration(48*time.Hour + 2*time.Minute))
+	compare(t, "1d", duration(47*time.Hour + 48*time.Minute))
+	compare(t, "2h", duration(2*time.Hour + 4*time.Minute))
+	compare(t, "1h", duration(1*time.Hour + 59*time.Minute))
+	compare(t, "30m", duration(30*time.Minute + 5*time.Second))
+	compare(t, "2m", duration(2*time.Minute + 5*time.Second))
+	compare(t, "5s", duration(5*time.Second))
+}
+
+func compare(t *testing.T, expect string, s string) {
+	if expect != s {
+		t.Errorf("Expected '%s' got '%s'", expect, s)
+	}
+}


### PR DESCRIPTION
- For longer durations, it scales up to match the duration
- For shorter durations, will show a seconds value rather than always `[x]m0s`

Tests are mainly just to show how it behaves across different situations. The outputs currently used subjectively looked fine to me but could probably be changed further.